### PR TITLE
perf: state mutability and unused var

### DIFF
--- a/contracts/SafeProtocolRegistry.sol
+++ b/contracts/SafeProtocolRegistry.sol
@@ -119,7 +119,7 @@ contract SafeProtocolRegistry is ISafeProtocolRegistry, Ownable2Step {
         emit ModuleFlagged(module);
     }
 
-    function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
         return interfaceId == type(ISafeProtocolRegistry).interfaceId || interfaceId == type(IERC165).interfaceId;
     }
 }

--- a/contracts/SignatureValidatorManager.sol
+++ b/contracts/SignatureValidatorManager.sol
@@ -223,7 +223,7 @@ contract SignatureValidatorManager is RegistryManager, ISafeProtocolFunctionHand
      * @param interfaceId bytes4 interface id to be checked
      * @return true if interface is supported
      */
-    function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
         return
             interfaceId == type(IERC165).interfaceId ||
             interfaceId == type(ISafeProtocolSignatureValidatorManager).interfaceId ||

--- a/contracts/test/TestFallbackReceiver.sol
+++ b/contracts/test/TestFallbackReceiver.sol
@@ -10,7 +10,7 @@ contract TestFallbackReceiver {
 
     receive() external payable {
         // solhint-disable-next-line no-unused-vars
-        (bool success, bytes memory data) = ethReceiver.call{value: address(this).balance}("");
+        (bool success, ) = ethReceiver.call{value: address(this).balance}("");
         if (!success) {
             revert("Failed to send eth");
         }

--- a/contracts/test/TestPlugin.sol
+++ b/contracts/test/TestPlugin.sol
@@ -18,7 +18,7 @@ abstract contract BaseTestPlugin is ISafeProtocolPlugin {
         permissions = _requiresPermission;
     }
 
-    function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
         return interfaceId == type(ISafeProtocolPlugin).interfaceId || interfaceId == 0x01ffc9a7;
     }
 


### PR DESCRIPTION
**Changes in PR:**

- perf: restrict state mutability to pure
- perf: remove unused variable

implement performance recommendations from solidity compiler:

```
Warning: Unused local variable.
  --> contracts/test/TestFallbackReceiver.sol:13:24:
   |
13 |         (bool success, bytes memory data) = ethReceiver.call{value: address(this).balance}("");
   |                        ^^^^^^^^^^^^^^^^^


Warning: Function state mutability can be restricted to pure
   --> contracts/SafeProtocolRegistry.sol:122:5:
    |
122 |     function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
    |     ^ (Relevant source part starts here and spans across multiple lines).


Warning: Function state mutability can be restricted to pure
   --> contracts/SignatureValidatorManager.sol:226:5:
    |
226 |     function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
    |     ^ (Relevant source part starts here and spans across multiple lines).


Warning: Function state mutability can be restricted to pure
  --> contracts/test/TestPlugin.sol:21:5:
   |
21 |     function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
   |     ^ (Relevant source part starts here and spans across multiple lines).
```
